### PR TITLE
Update samples readme to match current  projects

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,28 +1,46 @@
 # .NET Core Samples
 
-The code samples here are simple, buildable projects which augment the .NET Core Documentation with demonstrative code snippets.  These samples are directly embedded into documentation.
+This folder contains all the sample code that is part of any topic under
+the .NET Core documentation. There are several different projects that
+are organized in sub-folders. These sub-folders are organized similar
+to the organization of the docs for .NET Core.
 
-Sample projects are broken up by language.  Here is an example general structure:
+Some of the articles will have more than one sample associated with them. 
+
+The readme.md file for each sample will refer to the article so that
+you can read more about the concepts covered in each sample.
+
+## building a sample
+
+You build the samples using the .NET CLI. You can download the CLI from
+[the .NET Core home page](http://microsoft.com/net/core). Then, execute
+these commands from the CLI in the directory of any sample:
 
 ```
-/samples
-   /concept-to-sample
-      /csharp
-         global.json
-         /src
-            File1.cs
-            project.json
-         /test
-            Test1.cs
-            project.json
-      /vb
-      /fsharp
+dotnet restore
+dotnet build
+dotnet run
 ```
+
+These will install any needed dependencies, build the project, and run
+the project respetively.
+
+Multi-project samples have instructions in their root directory in
+a `README.md` file.  
+
+Except where noted, all samples will build from the command line, on
+any platform supported by .NET Core. There are a few samples that are
+specific to Visual Studio, and will require Visual Studio 2015, Update 3
+or a newer version. In addition, some samples show platform specific features,
+and will require a specific platform.
+
+## Creating new samples
+
 If you wish to add a code sample:
 
 1. Your sample **must be part of a buildable project**
 2. Your sample **cannot be a Visual Studio Project**
-	- We do not want Windows and Visual Studio to be a dependency for people building these on their own.
+	- We do not want Windows and Visual Studio to be a dependency for people building these on their own. The only exception is if your sample highlights particular tooling and is referenced by a topic that explains the pre-requisites.
 3. Your sample shoud conform to the [corefx coding style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) to maintain consistency.
 	- Additionally, we prefer the use of `static` methods rather than instance methods when demonstrating something that doesn't require instantiating a new object.
 
@@ -31,25 +49,7 @@ We will eventually have a CI system in place to build these projects.
 To create a sample:
 
 1. File an [issue](https://github.com/dotnet/core-docs/issues) or add a comment to an existing one that you are working on it.
-2. For each set of samples that demonstrates a concept, add a project.json with your dependencies and target coreclr. Additionally,
-add a run command specifying the sample folder so people using VSCode or Visual Studio can run the sample directly:
-
- ```json
- 	{
-		"dependencies": {
-		    "System.Runtime":"4.0.0-*",
-		    "System.Linq":"4.0.0-*",
-		    "System.Console": "4.0.0-*"
-	    },
-      "commands": {
-        "run" : "<SAMPLE FOLDER>"
-      },
-	    "frameworks": {
-		    "dnxcore50":{}
-	    }
-    }
- ```
-
+2. Write the topic that explains the concepts demonstrated in your sample (example: `docs/standard/linq/where-clause.md`) 
 3. Write your sample (example: `WhereClause-Sample1.cs`)
 4. Create a Program.cs with a Main entry point that calls your samples. If there is already one there, add the call to your sample:
   ```c#
@@ -66,18 +66,21 @@ add a run command specifying the sample folder so people using VSCode or Visual 
   ```
   To to build and run your sample...
 
-5. Grab the latest coreclr:
+5. Restore dependencies
 
  ```    
-	dnvm upgrade latest -r coreclr -u
+	dotnet restore
  ```
 6. Go to the sample folder and Build to check for errors.
 
  ```
-    dnu build
+    dotnet build
  ```
 7. Run!
 
  ```
-    dnx run
+    dotnet run
  ```
+
+8. Add a readme.md
+    - This should include a brief description of the code, and refer people to the article that references the sample.


### PR DESCRIPTION
Fixes #757

This should reflect the current location of samples, and how we are linking sample code to the article that describe them.